### PR TITLE
Fix `policyNumber` field case to avoid `Field 'policynumber.keyword' not found` ValidationException

### DIFF
--- a/actions/policylookup/index.py
+++ b/actions/policylookup/index.py
@@ -51,7 +51,7 @@ def retrieveAndGenerate(question, policytype, policynumber, kbId, modelId, regio
                                     },
                                     {
                                         "startsWith": {
-                                            "key": "policynumber",
+                                            "key": "policyNumber",
                                             "value": policynumber
                                         }
                                     }
@@ -86,7 +86,7 @@ def retrieveAndGenerate(question, policytype, policynumber, kbId, modelId, regio
                                     },
                                     {
                                         "startsWith": {
-                                            "key": "policynumber",
+                                            "key": "policyNumber",
                                             "value": policynumber
                                         }
                                     }


### PR DESCRIPTION
*Issue #, if available:* fixes #1

*Description of changes:*
Fixes field name case in the RetrieveAndGenerate invocation to avoid ValidationException from OpenSearch Serverless index during policy lookup flow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
